### PR TITLE
헤로쿠에 배포하기 - DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ spring:
     activate:
       on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
clearDB의 기본 mysql 버전이 '5.6'으로 너무 낮기 때문에  
기본 mysql 버전이 '8.0'인 jawsDB로 교체하자 
이를 이용해 환경변수를 다시 작업함

This fixes #46 